### PR TITLE
Explicit pagination paths

### DIFF
--- a/app/views/newsfeed/index.html.slim
+++ b/app/views/newsfeed/index.html.slim
@@ -41,7 +41,7 @@ table border="0px"
             li
               = link_to post.title, post.link, style: "font-size: 14.5px; text-decoration: underline;", target: '_blank'
               br style="line-height:22px;"
-              i = post.date_created.strftime("%d %B %Y")
+              i = post.date_created
               br style="line-height:30px;"
       - else
         m = "Новостей пока нет"

--- a/app/views/newsfeed/index.html.slim
+++ b/app/views/newsfeed/index.html.slim
@@ -48,7 +48,7 @@ table border="0px"
 
 - if @posts.any?
   div width="100%" align="center"
-    = will_paginate @posts, renderer: BootstrapPagination::Rails, :previous_label => 'Назад', :next_label => 'Вперед'
+    = will_paginate @posts, renderer: BootstrapPagination::Rails, :previous_label => 'Назад', :next_label => 'Вперед', :params => { :controller => 'newsfeed', :action => 'index' }
 
 ruby:
   def all_tags

--- a/app/views/newsfeed/index.html.slim
+++ b/app/views/newsfeed/index.html.slim
@@ -39,7 +39,7 @@ table border="0px"
         - @posts.each do |post|
           div class="form-horizontal center"
             li
-              = link_to t(post.title), post.link, style: "font-size: 14.5px; text-decoration: underline;", target: '_blank'
+              = link_to post.title, post.link, style: "font-size: 14.5px; text-decoration: underline;", target: '_blank'
               br style="line-height:22px;"
               i = post.date_created.strftime("%d %B %Y")
               br style="line-height:30px;"

--- a/app/views/newsfeed_edit_import/index.html.slim
+++ b/app/views/newsfeed_edit_import/index.html.slim
@@ -23,7 +23,7 @@ div class="page-header"
 
 - if @import_news.any?
   div width="100%" align="center"
-    = will_paginate @import_news, renderer: BootstrapPagination::Rails, :previous_label => 'Назад', :next_label => 'Вперед'
+    = will_paginate @import_news, renderer: BootstrapPagination::Rails, :previous_label => 'Назад', :next_label => 'Вперед', :params => { :controller => 'newsfeed_edit_import', :action => 'index' }
 
 ruby:
   def all_tags

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,10 +136,12 @@ Octoshell::Application.routes.draw do
   resources :newsfeed_settings, only: [:new, :create, :index]
   resources :newsfeed_local, only: [:new, :create, :index]
 
+  get '/newsfeed', to: 'newsfeed#index', as: 'newsfeed'
   post '/newsfeed/', to: 'newsfeed#create', as: 'newsfeed_create'
   patch '/newsfeed/', to: 'newsfeed#update', as: 'newsfeed_patch'
   put '/newsfeed/', to: 'newsfeed#update', as: 'newsfeed_put'
 
+  get '/newsfeed_edit_import', to: 'newsfeed_edit_import#index', as: 'newsfeed_edit_import'
   post '/newsfeed_edit_import/', to: 'newsfeed_edit_import#create', as: 'newsfeed_edit_import_create'
   patch '/newsfeed_edit_import/', to: 'newsfeed_edit_import#update', as: 'newsfeed_edit_import_patch'
   put '/newsfeed_edit_import/', to: 'newsfeed_edit_import#update', as: 'newsfeed_edit_import_put'


### PR DESCRIPTION
В продакшн версии пагинация не работает как нужно – если проинспектировать в браузере, то несложно заметить неправильные пути, на которые ведут линки в кнопках (игнорируется текущий контроллер). Это может быть связано как с проблемой в роутинге приложения, так и в версии gem модуля **will_paginate**. 

В данных изменениях было сделано:
- Явно указаны пути роутинга к контроллерам `newsfeed` и `newsfeed_edit_import`
- Явно переданы параметры модулю **will_paginate** (контроллер и экшн)

Если не поможет, тогда нужно обновить gem'ы. 

Похожая проблема: https://github.com/mislav/will_paginate/issues/235